### PR TITLE
Codebuild template handler and InputResolver

### DIFF
--- a/src/pipeformer/internal/resolve.py
+++ b/src/pipeformer/internal/resolve.py
@@ -78,7 +78,9 @@ class InputResolver:
 
     @_wrapped.validator
     def _validate_wrapped(self, attribute, value):  # pylint: disable=unused-argument,no-self-use
-        """Validate characteristics about the wrapped object."""
+        """Validate characteristics about the wrapped object.
+        Used by attrs as the validator for the ``_wrapped`` attribute.
+        """
         if isinstance(value, InputResolver):
             raise TypeError(f"{InputResolver!r} cannot wrap itself.")
 

--- a/src/pipeformer/internal/resolve.py
+++ b/src/pipeformer/internal/resolve.py
@@ -1,0 +1,199 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Helpers for resolving custom formatting."""
+from typing import Iterable, Union
+
+import attr
+from attr.validators import deep_mapping, instance_of
+from troposphere import Join
+
+from .structures import Input
+
+_INPUT_TAG = ["{INPUT:", "}"]
+_PRIMITIVE_TYPES = (int, float, complex, bool, type(None))
+_PrimitiveTypes = Union[int, float, complex, bool, None]
+__all__ = ("InputResolver",)
+
+
+def _tag_in_string(source: str, start: str, end: str) -> bool:
+    """Determine if a specific tag is in a string.
+
+    :param source: String to evaluate
+    :param start: String that marks the start of a tag
+    :param end: String that marks the end of a tag
+    :returns: Decision
+    """
+    if start not in source:
+        return False
+
+    if end not in source[source.index(start) + len(start) :]:
+        return False
+
+    return True
+
+
+def _value_to_triplet(source: str, start: str, end: str) -> Iterable[str]:
+    """Extract the first tag value from a string, splitting the source string into the parts before and after the tag.
+
+    :param source: String to process
+    :param start: String that marks the start of a tag
+    :param end: String that marks the end of a tag
+    :return: Split string values
+    """
+    prefix, _value = source.split(start, 1)
+
+    value, suffix = _value.split(end, 1)
+
+    return prefix, value, suffix
+
+
+@attr.s(cmp=False)
+class InputResolver:
+    """Wraps another structure and injects input references whenever a value is found that contains an input tag.
+
+    As strings are read from the contents of the wrapped structure,
+    they are expanded as necessary to CloudFormation dynamic references that will resolve the needed input values.
+
+    Along the way, the referenced inputs are collected and can later be found in ``required_inputs``.
+    This can be used to determine what inputs are required as parameters for a given CloudFormation template.
+
+    :param wrapped: Wrapped structure
+    :param inputs: Map of input names to :class:`Input` structures
+    :param required_inputs: Known required input (optional)
+    """
+
+    _wrapped = attr.ib()
+    _inputs = attr.ib(validator=deep_mapping(key_validator=instance_of(str), value_validator=instance_of(Input)))
+    required_inputs = attr.ib(default=attr.Factory(set))
+
+    @_wrapped.validator
+    def _validate_wrapped(self, attribute, value):  # pylint: disable=unused-argument,no-self-use
+        """Validate characteristics about the wrapped object."""
+        if isinstance(value, InputResolver):
+            raise TypeError(f"{InputResolver!r} cannot wrap itself.")
+
+        for reserved in ("required_inputs",):
+            if hasattr(value, reserved):
+                raise TypeError(f'Wrapped object must not have "{reserved}" attribute.')
+
+    def __attrs_post_init__(self):
+        """Enable otherwise hidden wrapped methods if those methods are found on the wrapped object."""
+        for method in ("get", "keys", "values", "items"):
+            if hasattr(self._wrapped, method):
+                setattr(self, method, getattr(self, f"_{method}"))
+
+    def __expand_values(self, value: str) -> Iterable[str]:
+        """Expand a string into a prefix, input reference, and suffix."""
+        prefix, name, suffix = _value_to_triplet(value, *_INPUT_TAG)
+
+        input_definition = self._inputs[name]
+        reference = input_definition.dynamic_reference()
+
+        self.required_inputs.add(name)
+        return prefix, reference, suffix
+
+    def __convert_value(self, value) -> Union[_PrimitiveTypes, "InputResolver", str, Join]:
+        """Convert a value from the wrapped object to a value that can insert input resolutions."""
+        if isinstance(value, _PRIMITIVE_TYPES):
+            return value
+
+        if not isinstance(value, str):
+            return InputResolver(wrapped=value, inputs=self._inputs, required_inputs=self.required_inputs)
+
+        if not _tag_in_string(value, *_INPUT_TAG):
+            return value
+
+        return Join("", self.__expand_values(value))
+
+    def __len__(self):
+        """Passthrough length from wrapped."""
+        return len(self._wrapped)
+
+    def __eq__(self, other) -> bool:
+        """Passthrough eq from wrapped."""
+        if isinstance(other, InputResolver):
+            return self._wrapped.__eq__(other._wrapped)  # pylint: disable=protected-access
+        return self._wrapped.__eq__(other)
+
+    def __lt__(self, other) -> bool:
+        """Passthrough lt from wrapped."""
+        if isinstance(other, InputResolver):
+            return self._wrapped.__lt__(other._wrapped)  # pylint: disable=protected-access
+        return self._wrapped.__lt__(other)
+
+    def __gt__(self, other) -> bool:
+        """Passthrough gt from wrapped."""
+        if isinstance(other, InputResolver):
+            return self._wrapped.__gt__(other._wrapped)  # pylint: disable=protected-access
+        return self._wrapped.__gt__(other)
+
+    def __le__(self, other) -> bool:
+        """Passthrough le from wrapped."""
+        if isinstance(other, InputResolver):
+            return self._wrapped.__le__(other._wrapped)  # pylint: disable=protected-access
+        return self._wrapped.__le__(other)
+
+    def __ge__(self, other) -> bool:
+        """Passthrough ge from wrapped."""
+        if isinstance(other, InputResolver):
+            return self._wrapped.__ge__(other._wrapped)  # pylint: disable=protected-access
+        return self._wrapped.__ge__(other)
+
+    def __str__(self) -> str:
+        """Passthrough str from wrapped."""
+        # TODO: Do we need to convert this?
+        return self._wrapped.__str__()
+
+    def __getattr__(self, name):
+        """Get an attribute from wrapped and convert it."""
+        return self.__convert_value(getattr(self._wrapped, name))
+
+    def __call__(self, *args, **kwargs):
+        """Call wrapped and convert the result."""
+        return self.__convert_value(self._wrapped(*args, **kwargs))
+
+    def __getitem__(self, key):
+        """Get an item from wrapped and convert it."""
+        return self.__convert_value(self._wrapped[key])
+
+    def __iter__(self) -> Iterable["InputResolver"]:
+        """Iterate through wrapped, converting the results."""
+        for each in self._wrapped:
+            yield self.__convert_value(each)
+
+    def __reversed__(self) -> Iterable["InputResolver"]:
+        """Reverse wrapped, converting the result."""
+        return self.__convert_value(reversed(self._wrapped))
+
+    def __next__(self) -> "InputResolver":
+        """Iterate through wrapped, converting the results."""
+        return self.__convert_value(self._wrapped.__next__())
+
+    def _get(self, key, default=None) -> "InputResolver":
+        """Call wrapped.get, converting the result."""
+        return self.__convert_value(self._wrapped.get(key, default))
+
+    def _items(self) -> Iterable[Iterable["InputResolver"]]:
+        """Call wrapped.items, converting the resulting keys and values."""
+        for key, value in self._wrapped.items():
+            yield (self.__convert_value(key), self.__convert_value(value))
+
+    def _keys(self) -> Iterable["InputResolver"]:
+        """Call wrapped.keys, converting the resulting keys."""
+        for key in self._wrapped.keys():
+            yield self.__convert_value(key)
+
+    def _values(self) -> Iterable["InputResolver"]:
+        """Call wrapped.values, converting the resulting values."""
+        for value in self._wrapped.values():
+            yield self.__convert_value(value)

--- a/src/pipeformer/internal/templates/codebuild.py
+++ b/src/pipeformer/internal/templates/codebuild.py
@@ -1,0 +1,104 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Logic for building the CodeBuild stack templates."""
+import string
+
+from troposphere import AWS_STACK_NAME, Output, Parameter, Ref, Sub, Tags, Template, codebuild, iam, s3
+
+from pipeformer.internal.resolve import InputResolver
+from pipeformer.internal.structures import Config
+from pipeformer.internal.util import reference_name, resource_name
+
+from . import project_tags
+
+
+def project_name(action_number: int) -> str:
+    """Construct the project logical resource name.
+
+    :param action_number: Unique count identifier for project in stack
+    :return: Logical resource name
+    """
+    return resource_name(codebuild.Project, string.ascii_letters[action_number])
+
+
+def _build_project(name: str, action: InputResolver, role: Ref, bucket: Ref, tags: Tags) -> codebuild.Project:
+    """Construct a CodeBuild project for the specified action.
+
+    :param name: Logical resource name to use for project
+    :param action: Action wrapped in an InputResolver
+    :param role: Reference to CodeBuild role
+    :param bucket: Reference to application resources bucket
+    :param tags: Tags to add to project
+    :return: Constructed project
+    """
+    return codebuild.Project(
+        name,
+        Name=Sub(f"${{{AWS_STACK_NAME}}}-{name}"),
+        ServiceRole=role,
+        Artifacts=codebuild.Artifacts(Type="CODEPIPELINE"),
+        Source=codebuild.Source(Type="CODEPIPELINE", BuildSpec=action.buildspec),
+        Environment=codebuild.Environment(
+            ComputeType=action.compute_type,
+            Type=action.environment_type,
+            Image=action.image,
+            EnvironmentVariables=[codebuild.EnvironmentVariable(Name="PIPEFORMER_S3_BUCKET", Value=bucket)]
+            + [codebuild.EnvironmentVariable(Name=key, Value=value) for key, value in action.env.items()],
+        ),
+        Tags=tags,
+    )
+
+
+def build(project: Config, stage: InputResolver) -> Template:
+    """Build a stack template for all CodeBuild actions in a CodePipeline stage.
+
+    :param project: PipeFormer project to build for
+    :param stage: Stage for which to construct CodeBuild projects
+    :return: Constructed template
+    """
+    resources = Template(
+        Description=f"CodeBuild projects for {stage.name} stage in pipeformer-managed project: {project.name}"
+    )
+
+    # set all non-input parameters
+    resources_bucket = resources.add_parameter(
+        Parameter(reference_name(resource_name(s3.Bucket, "ProjectResources"), "Name"), Type="String")
+    )
+    role = resources.add_parameter(
+        Parameter(reference_name(resource_name(iam.Role, "CodeBuild"), "Arn"), Type="String")
+    )
+
+    default_tags = project_tags(project)
+
+    required_inputs = set()
+
+    # add all resources
+    for pos in range(len(stage.actions)):
+        action = stage.actions[pos]
+
+        if action.provider != "CodeBuild":
+            continue
+
+        action_resource = resources.add_resource(
+            _build_project(
+                name=project_name(pos), action=action, role=role.ref(), bucket=resources_bucket.ref(), tags=default_tags
+            )
+        )
+        resources.add_output(Output(reference_name(action_resource.title, "Name"), Value=action_resource.ref()))
+
+        required_inputs.update(action.required_inputs)
+
+    # use collected parameters to set all input values needed as parameters
+    for name in required_inputs:
+        resources.add_parameter(Parameter(project.inputs[name].reference_name(), Type="String"))
+
+    return resources

--- a/test/functional/internal/templates/test_codebuild.py
+++ b/test/functional/internal/templates/test_codebuild.py
@@ -1,0 +1,48 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Functional tests for ``pipeformer.internal.templates.codebuild``."""
+import pytest
+
+from pipeformer.internal.resolve import InputResolver
+from pipeformer.internal.templates import codebuild
+
+from ... import functional_test_utils
+
+pytestmark = [pytest.mark.local, pytest.mark.functional]
+
+
+@pytest.mark.parametrize("name", functional_test_utils.vector_names())
+@pytest.mark.parametrize("stage_name", ("build",))
+def test_parse_config(name: str, stage_name: str):
+    project = functional_test_utils.populated_config(name)
+    stage = InputResolver(
+        wrapped=project.pipeline[stage_name],  # attrs confuses pylint: disable=unsubscriptable-object
+        inputs=project.inputs,
+    )
+
+    _test = codebuild.build(project, stage)
+
+
+@pytest.mark.parametrize("name", functional_test_utils.vector_names())
+@pytest.mark.parametrize("stage_name", ("build",))
+def test_generate_template(name: str, stage_name: str):
+    project = functional_test_utils.populated_config(name)
+    stage = InputResolver(
+        wrapped=project.pipeline[stage_name],  # attrs confuses pylint: disable=unsubscriptable-object
+        inputs=project.inputs,
+    )
+    expected = functional_test_utils.load_vector_as_template(name, f"codebuild-{stage_name}")
+
+    test = codebuild.build(project, stage)
+
+    assert test.to_json() == expected.to_json()

--- a/test/unit/internal/test_resolve.py
+++ b/test/unit/internal/test_resolve.py
@@ -1,0 +1,300 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Unit tests for ``pipeformer.internal.resolve``."""
+import itertools
+import json
+import uuid
+from collections import namedtuple
+from typing import Union
+
+import pytest
+from troposphere import Join, Ref, Sub
+
+from pipeformer.internal.resolve import _PRIMITIVE_TYPES, InputResolver
+from pipeformer.internal.structures import Input
+
+pytestmark = [pytest.mark.local]
+
+Example = namedtuple("Example", ("value",))
+INPUTS = {
+    "ExampleOne": Input(name="ExampleOne", description="Example number one", secret=False),
+    "ExampleTwo": Input(name="ExampleTwo", description="Example number two", secret=True),
+}
+
+
+def resolved_strings():
+    for prefix, suffix in itertools.product(("", "prefix"), ("", "suffix")):
+        yield (
+            f"{prefix}{{INPUT:ExampleOne}}{suffix}",
+            Join("", [prefix, Sub("{{resolve:ssm:${name}:1}}", {"name": Ref("Parameter0ExampleOne0Name")}), suffix]),
+        )
+        yield (
+            f"{prefix}{{INPUT:ExampleTwo}}{suffix}",
+            Join(
+                "",
+                [
+                    prefix,
+                    Sub("{{resolve:secretsmanager:${arn}:SecretString}}", {"arn": Ref("Secret0ExampleTwo0Arn")}),
+                    suffix,
+                ],
+            ),
+        )
+    yield ("NoInput", "NoInput")
+    yield ("{INPUT:Broken", "{INPUT:Broken")
+    yield ("PUT:Broken}", "PUT:Broken}")
+
+
+def resolved_dicts():
+    source_map = {}
+    resolved_map = {}
+
+    for source, resolved in resolved_strings():
+        key = str(uuid.uuid4())
+        source_map[key] = source
+        resolved_map[key] = resolved
+
+    return source_map, resolved_map
+
+
+def _normalize_joins(source):
+    try:
+        return json.dumps(source.to_dict(), sort_keys=True)
+    except AttributeError:
+        return source
+
+
+SOURCE_DICT, RESOLVED_DICT = resolved_dicts()
+RESOLVED_VALUES = [_normalize_joins(value) for value in RESOLVED_DICT.values()]
+SOURCE_INVERSE = {value: key for key, value in SOURCE_DICT.items()}
+RESOLVED_INVERSE = {value: key for key, value in RESOLVED_DICT.items()}
+
+
+def _invert_dict(source):
+    return {_normalize_joins(value): key for key, value in source.items()}
+
+
+def _assert_resolved(actual, expected):
+    assert _normalize_joins(actual) == _normalize_joins(expected)
+
+
+def _assert_converted(value):
+    assert isinstance(value, (str, Join, InputResolver) + _PRIMITIVE_TYPES)
+
+
+class TestInputResolver:
+    def test_recurse(self):
+        test = InputResolver("asdf", INPUTS)
+
+        with pytest.raises(TypeError) as excinfo:
+            InputResolver(test, INPUTS)
+
+        excinfo.match(f"{InputResolver!r} cannot wrap itself.")
+
+    @pytest.mark.parametrize("source, expected", resolved_strings())
+    def test_attribute_string(self, source: str, expected: Union[str, Join]):
+        wrapped = Example(value=source)
+        resolver = InputResolver(wrapped, INPUTS)
+
+        test = resolver.value
+
+        _assert_resolved(test, expected)
+
+    @pytest.mark.parametrize("source, _expected", resolved_strings())
+    def test_required_inputs_resolution(self, source, _expected):
+        wrapped = Example(value=source)
+        resolver = InputResolver(wrapped, INPUTS)
+
+        test = resolver.value
+
+        if source != test:
+            assert resolver.required_inputs
+        else:
+            assert not resolver.required_inputs
+
+    def test_expand_and_resolve_dict(self):
+        source = {"a": "{INPUT:ExampleTwo}"}
+        expected = {
+            "a": Join(
+                "",
+                ["", Sub("{{resolve:secretsmanager:${arn}:SecretString}}", {"arn": Ref("Secret0ExampleTwo0Arn")}), ""],
+            )
+        }
+        resolver = InputResolver(source, INPUTS)
+
+        test = dict(**resolver)
+        assert not isinstance(test, InputResolver)
+        assert test["a"].to_dict() == expected["a"].to_dict()
+
+    def test_transitive_required_inputs(self):
+        Test = namedtuple("Test", ("value_1", "value_2"))
+        values = Test(value_1="{INPUT:ExampleOne}", value_2={"a": "{INPUT:ExampleTwo}"})
+
+        resolver = InputResolver(wrapped=values, inputs=INPUTS)
+
+        _resolve_example_one = resolver.value_1
+
+        assert resolver.required_inputs == {"ExampleOne"}
+
+        extract_dictionary = resolver.value_2
+
+        assert isinstance(extract_dictionary, InputResolver)
+
+        _resolve_values = dict(**extract_dictionary)
+
+        assert resolver.required_inputs == {"ExampleOne", "ExampleTwo"}
+
+    def test_str(self):
+        resolver = InputResolver("test", INPUTS)
+
+        assert str(resolver) == "test"
+
+    @pytest.mark.parametrize("value", (42, 42.0, complex(42), False, True, None))
+    def test_attribute_primitive_types(self, value):
+        source = Example(value=value)
+        resolver = InputResolver(source, INPUTS)
+
+        test = resolver.value
+
+        assert not isinstance(test, InputResolver)
+        assert type(test) is type(value)
+        assert test == value
+
+    def test_attribute_other(self):
+        source = Example(value=42)
+        resolver = InputResolver(source, INPUTS)
+
+        test = resolver.value
+
+        _assert_converted(test)
+        assert test == 42
+
+    def test_equality(self):
+        a = InputResolver(42, INPUTS)
+        b = InputResolver(76, INPUTS)
+        c = InputResolver(42, INPUTS)
+
+        assert a < b
+        assert b > c
+        assert a == c
+        assert a != b
+        assert b >= c
+        assert a >= c
+        assert a <= b
+        assert a <= c
+
+        assert a == 42
+        assert a != 99
+        assert a > 8
+        assert a >= 42
+        assert a >= 8
+        assert a < 99
+        assert a <= 42
+
+    def test_item(self):
+        source = {"a": 42}
+        resolver = InputResolver(source, INPUTS)
+
+        test = resolver["a"]
+
+        _assert_converted(test)
+        assert test == 42
+
+    def test_len(self):
+        source = "asdf"
+        resolver = InputResolver(source, INPUTS)
+
+        assert len(resolver) == len(source)
+
+    @pytest.mark.parametrize("source, expected", resolved_strings())
+    def test_call(self, source, expected):
+        def example():
+            return source
+
+        resolver = InputResolver(example, INPUTS)
+
+        _assert_resolved(resolver(), expected)
+
+    @pytest.mark.parametrize("pos", list(range(4)))
+    def test_iter(self, pos: int):
+        source = [1, 2, 3, 4]
+        resolver = InputResolver(source, INPUTS)
+
+        test = [i for i in resolver]
+
+        _assert_converted(test[pos])
+        assert test[pos] == source[pos]
+
+    def test_next(self):
+        source = iter([1, 2, 3, 4])
+        resolver = InputResolver(source, INPUTS)
+
+        a = next(resolver)
+        _assert_converted(a)
+
+    @pytest.mark.parametrize("pos", list(range(4)))
+    def test_reversed(self, pos: int):
+        source = [1, 2, 3, 4]
+        rev_source = list(reversed(source))
+        resolver = InputResolver(source, INPUTS)
+
+        test = [i for i in reversed(resolver)]
+
+        _assert_converted(test[pos])
+        assert test[pos] == rev_source[pos]
+
+    def test_invalid_inputs_value(self):
+        with pytest.raises(TypeError) as _excinfo:
+            InputResolver("test", {"a": "b"})
+
+    def test_invalid_wrapped_has_required_inputs(self):
+        Invalid = namedtuple("Invalid", ("required_inputs",))
+
+        test = Invalid(required_inputs="asdf")
+
+        with pytest.raises(TypeError) as excinfo:
+            InputResolver(test, inputs=INPUTS)
+
+        excinfo.match(r'Wrapped object must not have "required_inputs" attribute.')
+
+    @pytest.mark.parametrize("key", SOURCE_DICT.keys())
+    def test_get(self, key):
+        resolver = InputResolver(SOURCE_DICT, INPUTS)
+
+        test = resolver.get(key)
+
+        _assert_resolved(test, RESOLVED_DICT[key])
+
+    def test_resolve_values(self):
+        resolver = InputResolver(SOURCE_DICT, INPUTS)
+
+        for each in resolver.values():
+            _assert_converted(each)
+            assert _normalize_joins(each) in RESOLVED_VALUES
+
+    def test_resolve_keys(self):
+        resolver = InputResolver(SOURCE_INVERSE, INPUTS)
+
+        for each in resolver.keys():
+            _assert_converted(each)
+            assert _normalize_joins(each) in RESOLVED_VALUES
+
+    @pytest.mark.parametrize("source", (SOURCE_DICT, SOURCE_INVERSE))
+    def test_resolve_items(self, source):
+        resolver = InputResolver(source, INPUTS)
+
+        for key, value in resolver.items():
+            _assert_converted(key)
+            assert _normalize_joins(key) in list(RESOLVED_DICT.keys()) + RESOLVED_VALUES
+
+            _assert_converted(value)
+            assert _normalize_joins(value) in list(RESOLVED_DICT.keys()) + RESOLVED_VALUES


### PR DESCRIPTION
*Description of changes:*
This adds the CodeBuild template handler as well as the InputResolver.

`InputResolver` is a bit weird; what it does is to wrap another structure and recurse through the wrapped contents, expanding strings into CloudFormation `Join`s that inject the correct dynamic references to enable [input name resolution](https://github.com/awslabs/pipeformer/blob/master/CONFIG_FORMAT.rst#input-value-resolution).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
